### PR TITLE
Add TR7

### DIFF
--- a/scheme-id.pose
+++ b/scheme-id.pose
@@ -106,6 +106,10 @@
  (description "TinyScheme")
  (contact "Dimitrios Souflis"))
 
+((id "tr7")
+ (description "TR7")
+ (contact "José Bollo"))
+
 ((id "unsyntax")
  (description "Unsyntax")
  (contact "Marc Nieper-Wißkirchen"))


### PR DESCRIPTION
[TR7](https://gitlab.com/jobol/tr7) is an embeddable and configurable R7RS implementation written entirely in C.

TR7 was presented at FOSDEM 2022: https://archive.fosdem.org/2022/schedule/event/tinyscheme/