### PR TITLE
Add scheme-id meevax

### DIFF
--- a/scheme-id.pose
+++ b/scheme-id.pose
@@ -62,6 +62,10 @@
  (description "Loko Scheme")
  (contact "Göran Weinholt"))
 
+((id "meevax")
+ (description "Meevax")
+ (contact "Tatsuya Yamasaki"))
+
 ((id "mit")
  (description "MIT Scheme")
  (contact "Chris Hanson"))


### PR DESCRIPTION
[Meevax] is a R4RS-, R5RS- and R7RS-compliant interpreter written in C++ with support of several SRFIs.

@yamacir-kit If you are unhappy with adding Meevax to <https://registry.scheme.org/>, please inform.

[Meevax]: https://github.com/yamacir-kit/meevax